### PR TITLE
Update note - tutors values link.md

### DIFF
--- a/unit-0-getting-started/note-01-getting-started/note.md
+++ b/unit-0-getting-started/note-01-getting-started/note.md
@@ -13,7 +13,7 @@ Tutors is a collection of open source components and services supporting the cre
 
 - *Reader*: presents a Tutors course as an intuitive, discoverable and attractive [Web experience](https://tutors.dev/course/reference-course)
 
-These components are [developed in the open](https://github.com/tutors-sdk/tutors) by an active and friendly community, based on a clear [set of values](https://tutors.dev/note/tutors-reference-manual/unit-0/note-12).
+These components are [developed in the open](https://github.com/tutors-sdk/tutors) by an active and friendly community, based on a clear [set of values](https://next.tutors.dev/note/tutors-reference-manual/side-unit-4-ref/note-12-values).
 
 ### First Course
 


### PR DESCRIPTION
Link https://tutors.dev/note/tutors-reference-manual/unit-0/note-12 led to an empty page. Replaced it with correct link https://next.tutors.dev/note/tutors-reference-manual/side-unit-4-ref/note-12-values